### PR TITLE
Simplify send_vars and recv_vars

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -20,7 +20,18 @@ To begin communication with MAD-NG, you simply are required to do:
 Communication protocol
 ----------------------
 
-.. important:: **Before you send data to MAD-NG, you must always send MAD-NG the instructions to read the data. Before you receive any data from MAD-NG, you must always ask MAD-NG to send the data.**
+The communication protocol has been presented previously in a meeting that can be found here: `MAD-NG Python interface <https://indico.cern.ch/event/1224204/>`_. The essential points are:
+
+- PyMAD-NG communicates through pipes (first in, first out)
+- Communication occurs by sending MAD-NG scripts (as strings) to MAD
+- Retrieve data from MAD to Python pipe.
+- The stdout of MAD is redirected to the stdout of Python (not intercepted by PyMAD-NG)
+
+The first point is the most consequential for the user, as it means that the order in which you send data to MAD-NG is the order in which it will be received and vice versa for retrieving data. Therefore, you must adhere to the following rules:
+
+.. important:: 
+    - **Before you receive any data from MAD-NG, you must always ask MAD-NG to send the data.**
+    - **Before you send data to MAD-NG, you must always send MAD-NG the instructions to read the data.**
 
 .. code-block:: 
     :caption: An example of using the MAD object to communicate with MAD-NG

--- a/examples/ex-LowLevel/ex-send-multypes.py
+++ b/examples/ex-LowLevel/ex-send-multypes.py
@@ -104,4 +104,4 @@ py:send(MAD.nlogrange(1, 20, 20))
 """)
 print("irng", mad.recv() == range(3  , 12  , 2)) #Py not inclusive, mad is
 print("rng", mad.recv() == np.linspace(3.5, 21.4, 12))
-print("lrng", np.allclose(mad.recv(), np.logspace(1, 20, 20)))
+print("lrng", np.allclose(mad.recv(), np.geomspace(1, 20, 20)))

--- a/examples/ex-benchmark-and-fork/ex-benchmark-and-fork.py
+++ b/examples/ex-benchmark-and-fork/ex-benchmark-and-fork.py
@@ -48,7 +48,7 @@ if pid > 0:
         print(f"send {numVars} vals", time.time() - start_time)
 
         start_time = time.time()
-        mad.send_vars(list(varNameList), values)
+        mad.send_vars(**dict(zip(varNameList, values)))
         print(f"send {numVars} vals v2", time.time() - start_time)
 
         start_time = time.time()
@@ -58,7 +58,7 @@ if pid > 0:
         print(f"receive {numVars} vals", time.time() - start_time)
 
         start_time = time.time()
-        mad.recv_vars(list(varNameList))
+        mad.recv_vars(*varNameList)
         print(f"receive {numVars} vals v2", time.time() - start_time)
     print("proc1 ended", time.time() - start_time)
 else:
@@ -70,7 +70,7 @@ else:
         mad.seq.beam = mad.beam()
         mad["mtbl", "mflw"] = mad.twiss(sequence=mad.seq, method=4, chrom=True)
         plt.plot(mad.mtbl.s, mad.mtbl["beta11"])
-        plt.show()
+        # plt.show()
 
         # METHOD 2
         mad["circum", "lcell"] = 60, 20

--- a/src/pymadng/madp_classes.py
+++ b/src/pymadng/madp_classes.py
@@ -29,9 +29,9 @@ class madhl_ref(mad_ref):
     value: Union[str, int, float, np.ndarray, bool, list],
   ):
     if isinstance(item, int):
-      self.__mad__.send_vars(f"{self.__name__}[{item+1}]", value)
+      self.__mad__.send_vars(**{f"{self.__name__}[{item+1}]": value})
     elif isinstance(item, str):
-      self.__mad__.send_vars(f"{self.__name__}['{item}']", value)
+      self.__mad__.send_vars(**{f"{self.__name__}['{item}']": value})
     else:
       raise TypeError("Cannot index type of ", type(item), "expected string or int")
 

--- a/src/pymadng/madp_classes.py
+++ b/src/pymadng/madp_classes.py
@@ -6,6 +6,7 @@ from .madp_last import last_counter
 
 # TODO: Are you able to store the actual parent? 
 # TODO: Verify if functions need kwargs or not. (I would  not)
+# TODO: Allow __setitem__ to work with multiple indices (Should be a simple recursive loop)
 
 MADX_methods = ["load", "open_env", "close_env"]
 class madhl_ref(mad_ref):    

--- a/src/pymadng/madp_object.py
+++ b/src/pymadng/madp_object.py
@@ -42,7 +42,7 @@ class MAD(object):
     Returns:
       A MAD object, allowing for communication with MAD-NG
     """
-    # ----------------------- Create the process --------------------------#
+    # --------------------- Overload recv_ref functions ---------------------- #
     lst_cntr = last_counter(num_temp_vars)
     # Override the type of reference created by python.
     def recv_ref(self: mad_process) -> madhl_ref:
@@ -57,11 +57,13 @@ class MAD(object):
     str_to_fun["ref_"]["recv"] = recv_ref
     str_to_fun["obj_"]["recv"] = recv_obj
     str_to_fun["fun_"]["recv"] = recv_fun
+    # ------------------------------------------------------------------------ #
 
+    # ------------------------- Create the process --------------------------- #
     mad_path = mad_path or bin_path + "/mad_" + platform.system()
     self.__process = mad_process(mad_path, py_name, debug)
     self.__process.ipython_use_jedi = ipython_use_jedi
-    #----------------------------------------------------------------------#
+    # ------------------------------------------------------------------------ #
 
     ## Store the relavent objects into a function to get reference objects
     self.__mad_reflast = lambda: madhl_reflast(self.__process, lst_cntr)

--- a/src/pymadng/madp_object.py
+++ b/src/pymadng/madp_object.py
@@ -210,13 +210,10 @@ class MAD(object):
     Send the variables in vars with the names in names to MAD-NG.
 
     Args:
-      names (str/List[str]): The name(s) that would like to assign your python variable(s) in MAD-NG.
       **vars (List[str/int/float/ndarray/bool/list]): The variables to send with the assigned name in MAD-NG by the keyword argument.
 
     Raises:
-      AssertionError: A list of names must be matched with a list of variables
-      AssertionError: The number of names must match the number of variables
-      Other Errors: See :meth:`send`.
+      See :meth:`send`.
     """
     self.__process.send_vars(**vars)
 

--- a/src/pymadng/madp_pymad.py
+++ b/src/pymadng/madp_pymad.py
@@ -298,9 +298,9 @@ def recv_list(self: mad_process) -> list:
   vals = [self.recv(varname and varname + f"[{i+1}]") for i in range(lstLen)]
   self.varname = varname  # reset
   if haskeys and lstLen == 0:
-    return recv_ref(self)
+    return str_to_fun["ref_"]["recv"](self)
   elif haskeys:
-    return vals, recv_ref(self)
+    return vals, str_to_fun["ref_"]["recv"](self)
   else:
     return vals
 

--- a/src/pymadng/madp_pymad.py
+++ b/src/pymadng/madp_pymad.py
@@ -12,6 +12,11 @@ def get_typestring(a: Union[str, int, float, np.ndarray, bool, list]):
     else:                   return float
   else:
     return type(a)
+
+def is_not_private(varname):
+  if varname[:2] == "__" and varname[:8] != "__last__":
+    return False
+  return True
   
 data_types = {
   type(None)              : "nil_",
@@ -24,6 +29,7 @@ data_types = {
   np.complex128           : "cpx_",
   bool                    : "bool",
   list                    : "tbl_",
+  tuple                   : "tbl_",
   range                   : "irng",
   np.dtype("float64")     : "mat_",
   np.dtype("complex128")  : "cmat",
@@ -125,31 +131,19 @@ class mad_process:
     return env
 
   # ----------------- Dealing with communication of variables ---------------#
-  def send_vars(self, names, vars):
-    if isinstance(names, str): 
-      names = [names]
-      vars = [vars]
-    else:
-      assert isinstance(vars, list), "A list of names must be matched with a list of variables"
-      assert len(vars) == len(names), "The number of names must match the number of variables"
-    for i, var in enumerate(vars):
-      if isinstance(vars[i], mad_ref):
-        self.send(f"{names[i]} = {var.__name__}")
+  def send_vars(self, **vars):
+    for name, var in vars.items():
+      if isinstance(var, mad_ref):
+        self.send(f"{name} = {var.__name__}")
       else:
-        self.send(f"{names[i]} = {self.py_name}:recv()").send(var)
+        self.send(f"{name} = {self.py_name}:recv()").send(var)
 
-  def recv_vars(self, names) -> Any:
-    if isinstance(names, str): 
-      names = [names]
-      cnvrt = lambda rtrn: rtrn[0]
-    else: 
-      cnvrt = lambda rtrn: tuple(rtrn)
-
-    rtrn_vars = []
-    for name in names:
-      if name[:2] != "__" or name[:8] == "__last__":  # Check for private variables
-        rtrn_vars.append(self.precv(name))        
-    return cnvrt(rtrn_vars)
+  def recv_vars(self, *names) -> Any:
+    if len(names) == 1:
+      if is_not_private(names[0]):
+        return self.precv(names[0])
+    else:
+      return tuple(self.precv(name) for name in names if is_not_private(name))
 
   # -------------------------------------------------------------------------#
 


### PR DESCRIPTION
Instead of 
```python
mad.send_vars(["a", "b", "c"], [1, 2, 3])
a, b, c = mad.recv_vars(["a", "b", "c"])
print(a, b, c) #-> 1, 2, 3
```
Now:
```python
mad.send_vars(a = 1, b = 2, c = 3)
a, b, c = mad.recv_vars("a", "b", "c")
print(a, b, c) #-> 1, 2, 3
``` 
The second one feels cleaner and is less prone to user error?
